### PR TITLE
Add year to Hyrum's law and fix yaml error

### DIFF
--- a/_laws/hyrum.md
+++ b/_laws/hyrum.md
@@ -1,9 +1,10 @@
 ---
 layout: post
 title: Hyrum's Law
-law: With a sufficient number of users of an API, it does not matter what you promise in the contract: all observable behaviors of your system will be depended on by somebody.
+law: "With a sufficient number of users of an API, it does not matter what you promise in the contract: all observable behaviors of your system will be depended on by somebody."
 law-author: Hyrum Wright
 law-url: https://www.hyrumslaw.com/
+law-year: 2012
 ---
 
 Given enough use, there is no such thing as a private implementation. That is, if an interface has enough consumers, they will collectively depend on every aspect of the implementation, intentionally or not. This effect serves to constrain changes to the implementation, which must now conform to both the explicitly documented interface, as well as the implicit interface captured by usage. We often refer to this phenomenon as "bug-for-bug compatibility."


### PR DESCRIPTION
Couldn't find a specific year but it couldn't have been earlier than 2012 based on [Hyrum's resume](https://www.hyrumwright.org/cv.html) and [this interview with Hyrum](https://open.spotify.com/episode/5R82UheRlidCqfTMek4Q5h?si=jWdbIeegTYqjbSgkoy8ILg).