### PR TITLE
a11y: fix color contrast

### DIFF
--- a/assets/css/scss/main.scss
+++ b/assets/css/scss/main.scss
@@ -43,7 +43,6 @@ blockquote {
   padding-left: 1.1rem;
   margin-left: 1rem;
   font-style: italic;
-  color: #ada8a8;
 }
 
 pre {


### PR DESCRIPTION
Fixes the color contrast for `blockquote` elements.

![screenshot showing a failing WCAG color contrast ratio for text nodes inside a blockquote element](https://github.com/user-attachments/assets/30281cb4-8b2a-45e2-890d-add849114dcd)
