### PR TITLE
Add no silver bullets

### DIFF
--- a/_essays/no-silver-bullet.md
+++ b/_essays/no-silver-bullet.md
@@ -1,7 +1,7 @@
 ---
 title: No Silver Bullet
 author: Fred Brooks
-link: http://worrydream.com/refs/Brooks-NoSilverBullet.pdf
+link: https://www.cs.unc.edu/techreports/86-020.pdf
 year: 1986
 ---
 


### PR DESCRIPTION
Fixes #17: Add No Silver Bullet to essays page. The essay was already in _essays/; updated its link to point to the UNC techreport PDF referenced in the issue (https://www.cs.unc.edu/techreports/86-020.pdf).